### PR TITLE
docs: fix example 'create curl command'

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ flowchart LR
 import fastify from 'fastify';
 import { createFromFastify3 } from 'jin-curlize';
 
-const fastify = require('fastify')({
+const server = fastify({
   logger: {
     transport: {
       target: 'pino-pretty',


### PR DESCRIPTION
Fixed 'create curl command' example since it redeclares `fastify` so it doesn't wok.